### PR TITLE
Split h5 with db1 filter

### DIFF
--- a/src/4_train_models/CNN/split_h5.py
+++ b/src/4_train_models/CNN/split_h5.py
@@ -32,7 +32,7 @@ arg_parser.add_argument("--cluster", "-c",
 
 arg_parser.add_argument("--csv-file", "-d",
     help= "Name of db1. Needed only for clustered split.",
-    default="../../../data/external/processed/BA_pMHCI_substracted.csv",
+    default="../../../data/external/processed/BA_pMHCI.csv",
 )
 arg_parser.add_argument("--output-path", "-o",
     help="Destination path for the generated splits. For clustered will be in --output-path/clustered and in \


### PR DESCRIPTION
Added the possibility to filter ids from db4.
This way one db4 encapsulating all cases can be generated once and subsequent selection of cases of interest can be done thanks to h5 symlinks using the `split_h5.py` script.