### PR TITLE
Refactor split_h5 to speed up computation

### DIFF
--- a/src/4_train_models/CNN/split_h5.py
+++ b/src/4_train_models/CNN/split_h5.py
@@ -7,9 +7,12 @@ import os
 import glob
 import argparse
 from sklearn.model_selection import StratifiedKFold, train_test_split
+from joblib import Parallel, delayed
 import numpy as np
 import random
 import pandas as pd
+import pickle
+import tqdm
 
 arg_parser = argparse.ArgumentParser(
     description="This script combines every h5 files provided in the --features-path argument\
@@ -30,6 +33,18 @@ arg_parser.add_argument("--cluster", "-c",
     action = "store_true",
 )
 
+arg_parser.add_argument("--single-split", "-s",
+    help = "Do not make multiple splits for cross validation but just a single train-test-validate with test being value 0 in 'cluster' column.",
+    default = False,
+    action = "store_true",
+)
+
+arg_parser.add_argument("--parallel", "-p",
+    help = "runs the process in parallel on a slurm cluster",
+    default = False,
+    action = "store_true",
+)
+
 arg_parser.add_argument("--csv-file", "-d",
     help= "Name of db1. Needed only for clustered split.",
     default="../../../data/external/processed/BA_pMHCI.csv",
@@ -45,31 +60,6 @@ a = arg_parser.parse_args()
 
 # Change the combined_path and output_h5:
 output_h5_path = a.output_path
-
-def h5_symlinks(input_path, ids):
-    """Combines HDF5 files from the input_path folder
-    into a dictionaries of symlinks which then will be splited.
-    Return values:
-    - symlinks: symlink dictionary where the key is the model name (caseID)
-    and the value is the HDF5 file where the caseID is stored.
-    - labels: model's labels from every HDF5 files ordered in the same order
-    as the keys in the symlinks variable.
-    """
-    hfiles = glob.glob(f"{input_path}*.hdf5")
-    symlinks = {}
-    labels = []
-    for hfile in hfiles:
-        try:
-            caseIDs, case_labels = read_caseIDS_from_hfile(hfile, ids)
-        except:
-            print('#########')
-            print(f'Problem occurred with hdf5 file {hfile}')
-            #raise Exception(f'Problem occurred with hdf5 file {hfile}')
-        labels = labels + case_labels
-        for caseID in caseIDs:
-            symlinks[caseID] = hfile
-    return symlinks, labels
-
 
 def read_caseIDS_from_hfile(hfile, ids):
     """Read a hdf5 file, returns 2 lists:
@@ -92,8 +82,30 @@ def read_caseIDS_from_hfile(hfile, ids):
                 #raise Exception(f'Problem occurred with case {case}')
     return caseIDs, labels
 
+def h5_symlinks(input_path, ids):
+    """Combines HDF5 files from the input_path folder
+    into a dictionaries of symlinks which then will be splited.
+    Return values:
+    - symlinks: symlink dictionary where the key is the model name (caseID)
+    and the value is the HDF5 file where the caseID is stored.
+    - labels: model's labels from every HDF5 files ordered in the same order
+    as the keys in the symlinks variable.
+    """
+    hfiles = glob.glob(os.path.join(input_path,'*.hdf5'))
+    symlinks = {}
+    # labels = []
+    
+    caseIDs, case_labels = zip(*Parallel(verbose=True, n_jobs=n_cores)(delayed(read_caseIDS_from_hfile)(hfile, ids) for hfile in hfiles))
+    for i, hfile in enumerate(hfiles):
+        for caseID in caseIDs[i]:
+            symlinks[caseID] = hfile
+    # flatten the list of labels
+    labels = [lab for sub_labels in case_labels for lab in sub_labels]
+    
+    return symlinks, labels
 
-def save_train_valid(train_idx, val_idx, test_idx, symlinks, path_out_folder,
+
+def save_train_valid(train_idx, val_idx, test_idx, symlinks, features_path, path_out_folder,
     train_f, valid_f, test_f
 ):
     """Creates the train, valid and test HDF5 files from the symlinks
@@ -111,41 +123,70 @@ def save_train_valid(train_idx, val_idx, test_idx, symlinks, path_out_folder,
     train_h5 = h5py.File(os.path.join(path_out_folder, train_f), 'w')
     val_h5 = h5py.File(os.path.join(path_out_folder, valid_f), 'w')
     test_h5 = h5py.File(os.path.join(path_out_folder, test_f), 'w')
+    
+    org_h5s = glob.glob(os.path.join(features_path,'*.hdf5'))
 
-    print("### Creating train.hdf5 file ###") 
-    for i in train_idx:
-        symlink_in_h5(i, symlinks[i], train_h5) 
+    print("### Creating train.hdf5 file ###")
+    for org_h5 in tqdm.tqdm(org_h5s):
+        entries = [] 
+        for i, value_id in enumerate(train_idx):
+            try:
+                if symlinks[value_id] == org_h5:
+                    entries.append(value_id)
+                    train_idx = np.delete(train_idx, np.where(train_idx ==i))
+            except KeyError as ie:
+                print(ie)
+                print(f'train id not found in hdf5 files {value_id}') 
+        symlink_in_h5(entries, org_h5, train_h5)
 
     print("### Creating validation.hdf5 file ###") 
-    for i in val_idx:
-        symlink_in_h5(i, symlinks[i], val_h5) 
+    for org_h5 in tqdm.tqdm(org_h5s):
+        entries = [] 
+        for i, value_id in enumerate(val_idx):
+            try:
+                if symlinks[value_id] == org_h5:
+                    entries.append(value_id)
+                    val_idx = np.delete(val_idx, np.where(val_idx ==i))
+            except KeyError as ie:
+                print(ie)
+                print(f'train id not found in hdf5 files {value_id}') 
+        symlink_in_h5(entries, org_h5, test_h5)
 
     print("### Creating test.hdf5 file ###") 
-    for i in test_idx:
-        symlink_in_h5(i, symlinks[i], test_h5) 
-
+    for org_h5 in tqdm.tqdm(org_h5s):
+        entries = [] 
+        for i, value_id in enumerate(test_idx):
+            try:
+                if symlinks[value_id] == org_h5:
+                    entries.append(value_id)
+                    test_idx = np.delete(test_idx, np.where(test_idx ==i))
+            except KeyError as ie:
+                print(ie)
+                print(f'train id not found in hdf5 files {value_id}') 
+        symlink_in_h5(entries, org_h5, val_h5) 
+            
     train_h5.close()
     val_h5.close()
     test_h5.close()
 
 
-def symlink_in_h5(idx, f1_path, f2):
+def symlink_in_h5(indices, f1_path, f2):
     """Copy the selected keys (idx) of one hdf5 (f1) file into
      another hdf5 file (f2)
      idx = list of keys to copy
      f1 = handle of the first hdf5 file
      f2 = handle of the the second hdf5 file"""
-
-    # Get the name of the parent for the group we want to copy
-    f1 = h5py.File(f1_path, "r")
-    group_path = f1[idx].name
-
-    # Copy
-    f2[group_path] = h5py.ExternalLink(f1_path, group_path)
-    f1.close()
-
+    with h5py.File(f1_path, "r") as f1:
+        
+        for idx in indices:
+            group_path = f1[idx].name
+            f2[group_path] = h5py.ExternalLink(f1_path, group_path)
+        
 
 if __name__ == '__main__':
+    
+    if a.parallel:
+        n_cores = int(os.getenv('SLURM_CPUS_ON_NODE'))
     # Combine the h5 files using the csv as a filter:
     df = pd.read_csv(a.csv_file)
     symlinks, labels = h5_symlinks(a.features_path, df["ID"].tolist())
@@ -153,11 +194,16 @@ if __name__ == '__main__':
     n_splits=10
 
     #Make the output directories if they are not present already
-    split_type = ('shuffled', 'clustered')[a.cluster]
-    for split in range(0,n_splits):
-        if not os.path.isdir(output_h5_path + f"/{split_type}/{split}"):
-            os.makedirs(output_h5_path + f"/{split_type}/{split}")
-
+    if not a.single_split:
+        split_type = ('shuffled', 'clustered')[a.cluster]
+        for split in range(0,n_splits):
+            if not os.path.isdir(output_h5_path + f"/{split_type}/{split}"):
+                os.makedirs(output_h5_path + f"/{split_type}/{split}")
+    else:
+        split_type = ('shuffled', 'clustered')[a.cluster]
+        if not os.path.isdir(output_h5_path + f"/{split_type}/"):
+            os.makedirs(output_h5_path + f"/{split_type}/")
+            
     if a.cluster == False:
         all_cases = np.array(list(symlinks.keys()))
         labels = np.array(labels)
@@ -182,19 +228,33 @@ if __name__ == '__main__':
     else:
         groups = [int(x) for x in set(df["cluster"])]
         all_cases = list(symlinks.keys())
+        print(f'groups: {groups}')
         for i in groups:
             test_mask = (df["ID"].isin(all_cases)) & (df["cluster"] == i)
             test_cases = df[test_mask]["ID"]
+            print(f'test cases: {test_cases.shape}')
             not_test_cases = np.array(df[test_mask == False]["ID"])
+            print(f'not test case {not_test_cases.shape}')
             random.shuffle(not_test_cases)
             ds_l = not_test_cases.shape[0]
             train_cases, validation_cases = np.split(
                 not_test_cases, 
-                [int(0.7*ds_l)]
+                [int(0.9*ds_l)]
             )
-            print(f"### SAVING SPLITS FOR CLUSTER {i}")
-            save_train_valid(train_cases, validation_cases, test_cases, symlinks, output_h5_path,
-                f"clustered/{i}/train.hdf5",
-                f"clustered/{i}/valid.hdf5",
-                f"clustered/{i}/test.hdf5"
-            )
+
+            if a.single_split:
+                print(f"### SAVING SPLITS FOR TRAIN/TEST/VALIDATION")
+                save_train_valid(train_cases, validation_cases, test_cases, symlinks, a.features_path, output_h5_path,
+                    f"clustered/train.hdf5",
+                    f"clustered/valid.hdf5",
+                    f"clustered/test.hdf5"
+                )
+                # only single split so break loop
+                break
+            else:
+                print(f"### SAVING SPLITS FOR CLUSTER {i}")
+                save_train_valid(train_cases, validation_cases, test_cases, symlinks, a.features_path, output_h5_path,
+                    f"clustered/{i}/train.hdf5",
+                    f"clustered/{i}/valid.hdf5",
+                    f"clustered/{i}/test.hdf5"
+                )


### PR DESCRIPTION
I have rewritten this module mainly because of computation time (I think I estimated it would run for approx 6-8 hours).
The main modification is that a list of entries with the same source hdf5 file are grouped together. 
So in the old module each hdf5 file was opened n/64 times (with n the total number of pMHC entries and 64 the number of hdf5 files), which is in the thousands. With the grouped lists the files are opened only 3 times.

There is also a command line option to only make a single split based on the 'cluster' column (so only 1 train-test-validation combo)

