### PR TITLE
add atomic densities to generate_features script

### DIFF
--- a/src/3_build_db4/generate_features.py
+++ b/src/3_build_db4/generate_features.py
@@ -53,7 +53,7 @@ database.create_database(prog_bar=True)
 # mapping features:
 grid_info = {
     "number_of_points": [35,30,30],
-    # "number_of_points": [1,1,1],
+    "atomic_densities": {'C': 1.7, 'N': 1.55, 'O': 1.52, 'S': 1.8},
     "resolution": [1.,1.,1.]
 }
 


### PR DESCRIPTION
Add the atomic densities to the generate features script so that this features is also explicitly added to the hdf5 files.